### PR TITLE
fix: add workaround for routes that return incorrect value for `isGithubCloudOnly`

### DIFF
--- a/lib/definition-to-endpoint.js
+++ b/lib/definition-to-endpoint.js
@@ -1,6 +1,7 @@
 module.exports = definitionToEndpoint;
 
 const schemaToParameters = require("./schema-to-parameters");
+const { applyWorkaround } = require("./workarounds");
 
 function definitionToEndpoint({ method, url }, definition) {
   const parameters = {};
@@ -186,6 +187,8 @@ function definitionToEndpoint({ method, url }, definition) {
   if (acceptHeader.required) {
     endpoint.headers.unshift(toHeader(acceptHeader));
   }
+
+  applyWorkaround(endpoint);
 
   return endpoint;
 }

--- a/lib/get-vercel-url.js
+++ b/lib/get-vercel-url.js
@@ -9,5 +9,7 @@ function getVercelUrl() {
     return "http://localhost:3000";
   }
 
-  return `https://${process.env.VERCEL_URL}`;
+  return /^http/.test(process.env.VERCEL_URL)
+    ? process.env.VERCEL_URL
+    : `https://${process.env.VERCEL_URL}`;
 }

--- a/lib/workarounds.js
+++ b/lib/workarounds.js
@@ -1,0 +1,53 @@
+module.exports = {
+  applyWorkaround,
+};
+
+function applyWorkaround(endpoint) {
+  setIsGithubCloudOnly(endpoint);
+}
+
+const IS_GITHUB_ONLY_ROUTES = [
+  "PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}",
+  "POST /orgs/{org}/actions/runner-groups",
+  "DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}",
+  "GET /orgs/{org}/actions/runner-groups/{runner_group_id}",
+  "GET /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories",
+  "GET /orgs/{org}/actions/runner-groups",
+  "GET /orgs/{org}/actions/runner-groups/{runner_group_id}/runners",
+  "DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories/{repository_id}",
+  "DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}",
+  "PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories",
+  "PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/runners",
+  "PATCH /orgs/{org}/actions/runner-groups/{runner_group_id}",
+  "PUT /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations/{org_id}",
+  "PUT /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners/{runner_id}",
+  "POST /enterprises/{enterprise}/actions/runners/registration-token",
+  "POST /enterprises/{enterprise}/actions/runners/remove-token",
+  "POST /enterprises/{enterprise}/actions/runner-groups",
+  "DELETE /enterprises/{enterprise}/actions/runners/{runner_id}",
+  "DELETE /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}",
+  "GET /enterprises/{enterprise}/actions/runners/{runner_id}",
+  "GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}",
+  "GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations",
+  "GET /enterprises/{enterprise}/actions/runners/downloads",
+  "GET /enterprises/{enterprise}/actions/runner-groups",
+  "GET /enterprises/{enterprise}/actions/runners",
+  "GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners",
+  "DELETE /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations/{org_id}",
+  "DELETE /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners/{runner_id}",
+  "PUT /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations",
+  "PUT /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners",
+  "PATCH /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}",
+];
+
+/**
+ * Due to complications in how the OpenAPI artifacts are currently generated, the `isGithubCloudOnly`
+ * is currently not set to `false` for several routes.
+ */
+function setIsGithubCloudOnly(endpoint) {
+  const route = [endpoint.method, endpoint.url].join(" ");
+
+  if (IS_GITHUB_ONLY_ROUTES.includes(route)) {
+    endpoint.isGithubCloudOnly = true;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "GraphQL server for GitHub's REST API specifications",
   "scripts": {
     "start": "vercel dev",
-    "test": "ava",
+    "test": "ava -s",
     "build": "node scripts/build-graphql-schema.js"
   },
   "keywords": [

--- a/test/github-cloud-only-workaround-test.js
+++ b/test/github-cloud-only-workaround-test.js
@@ -1,0 +1,77 @@
+const test = require("ava");
+const got = require("got");
+
+const VERCEL_URL = require("../lib/get-vercel-url")();
+
+const graphql = got.extend({
+  prefixUrl: `${VERCEL_URL}/api/`,
+  responseType: "json",
+  resolveBodyOnly: true,
+  method: "POST",
+});
+
+test.before(async () => {
+  try {
+    await got(VERCEL_URL, { method: "HEAD" });
+  } catch (error) {
+    throw new Error(
+      `Server is not running at ${VERCEL_URL}. Try "npm start" in a separate tab`
+    );
+  }
+});
+
+const workaroundRoutes = [
+  "PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}",
+  "POST /orgs/{org}/actions/runner-groups",
+  "DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}",
+  "GET /orgs/{org}/actions/runner-groups/{runner_group_id}",
+  "GET /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories",
+  "GET /orgs/{org}/actions/runner-groups",
+  "GET /orgs/{org}/actions/runner-groups/{runner_group_id}/runners",
+  "DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories/{repository_id}",
+  "DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}",
+  "PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories",
+  "PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/runners",
+  "PATCH /orgs/{org}/actions/runner-groups/{runner_group_id}",
+  "PUT /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations/{org_id}",
+  "PUT /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners/{runner_id}",
+  "POST /enterprises/{enterprise}/actions/runners/registration-token",
+  "POST /enterprises/{enterprise}/actions/runners/remove-token",
+  "POST /enterprises/{enterprise}/actions/runner-groups",
+  "DELETE /enterprises/{enterprise}/actions/runners/{runner_id}",
+  "DELETE /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}",
+  "GET /enterprises/{enterprise}/actions/runners/{runner_id}",
+  "GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}",
+  "GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations",
+  "GET /enterprises/{enterprise}/actions/runners/downloads",
+  "GET /enterprises/{enterprise}/actions/runner-groups",
+  "GET /enterprises/{enterprise}/actions/runners",
+  "GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners",
+  "DELETE /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations/{org_id}",
+  "DELETE /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners/{runner_id}",
+  "PUT /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations",
+  "PUT /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners",
+  "PATCH /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}",
+];
+
+for (const route of workaroundRoutes) {
+  test(`"${route}" should return "isGithubCloudOnly: true"`, async (t) => {
+    const query = `query ($version: String!, $route: String!) {
+      endpoint(version: $version, route: $route) {
+        isGithubCloudOnly
+      }
+    }
+    `;
+    const expected = { endpoint: { isGithubCloudOnly: true } };
+    const { data } = await graphql("graphql", {
+      json: {
+        query,
+        variables: {
+          version: "5.6.1",
+          route,
+        },
+      },
+    });
+    t.deepEqual(data, expected);
+  });
+}


### PR DESCRIPTION
- `PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}`
- `POST /orgs/{org}/actions/runner-groups`
- `DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}`
- `GET /orgs/{org}/actions/runner-groups/{runner_group_id}`
- `GET /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories`
- `GET /orgs/{org}/actions/runner-groups`
- `GET /orgs/{org}/actions/runner-groups/{runner_group_id}/runners`
- `DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories/{repository_id}`
- `DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}`
- `PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories`
- `PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/runners`
- `PATCH /orgs/{org}/actions/runner-groups/{runner_group_id}`
- `PUT /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations/{org_id}`
- `PUT /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners/{runner_id}`
- `POST /enterprises/{enterprise}/actions/runners/registration-token`
- `POST /enterprises/{enterprise}/actions/runners/remove-token`
- `POST /enterprises/{enterprise}/actions/runner-groups`
- `DELETE /enterprises/{enterprise}/actions/runners/{runner_id}`
- `DELETE /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}`
- `GET /enterprises/{enterprise}/actions/runners/{runner_id}`
- `GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}`
- `GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations`
- `GET /enterprises/{enterprise}/actions/runners/downloads`
- `GET /enterprises/{enterprise}/actions/runner-groups`
- `GET /enterprises/{enterprise}/actions/runners`
- `GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners`
- `DELETE /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations/{org_id}`
- `DELETE /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners/{runner_id}`
- `PUT /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations`
- `PUT /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners`
- `PATCH /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}`